### PR TITLE
Improve controller notifications

### DIFF
--- a/cmd/workflow-engine/app/bootstrap_test.go
+++ b/cmd/workflow-engine/app/bootstrap_test.go
@@ -196,7 +196,7 @@ func TestWorkflowInvocation(t *testing.T) {
 	}
 
 	if !invocation.Status.Status.Successful() {
-		t.Errorf("Invocation status is not succesfull,s but '%v", invocation.Status.Status)
+		t.Errorf("Invocation status is not 'succesfull', instead it is '%v'", invocation.Status.Status)
 	}
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: eb497c68c230f80855d9c4ac635d17fe0ab9d331d7860726881f719ee560224b
-updated: 2017-08-22T19:05:22.898750196-07:00
+hash: a081108074a8ed5da5b5f8190bb64155065875a9e55f127e63b9cea6a0f24800
+updated: 2017-08-23T17:27:58.230766466-07:00
 imports:
 - name: github.com/fission/fission
   version: 37aa266a4d4bd0484e66afbc5206b118638e77bf
@@ -12,6 +12,8 @@ imports:
   - gogoproto
   - proto
   - protoc-gen-gogo/descriptor
+- name: github.com/golang/glog
+  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/protobuf
   version: 0a4f71a498b7c4812f64969510bcb4eca251e33a
   subpackages:
@@ -36,15 +38,13 @@ imports:
   - utilities
 - name: github.com/nats-io/go-nats
   version: 29f9728a183bf3fa7e809e14edac00b33be72088
+  subpackages:
+  - encoders/builtin
+  - util
 - name: github.com/nats-io/go-nats-streaming
   version: 6e620057a207bd61e992c1c5b6a2de7b6a4cb010
   subpackages:
   - pb
-- name: github.com/nats-io/nats
-  version: 43abfaad5f01e2185b415f0d9f9af47d846ee540
-  subpackages:
-  - encoders/builtin
-  - util
 - name: github.com/nats-io/nuid
   version: 289cccf02c178dc782430d534e3c1f5b72af807f
 - name: github.com/satori/go.uuid

--- a/glide.lock
+++ b/glide.lock
@@ -1,9 +1,10 @@
-hash: 4a7acdc04a8e081ead76be060b9679dc2760317f0380af1dd97e5a0787f4045f
-updated: 2017-08-01T17:24:39.69027853-07:00
+hash: eb497c68c230f80855d9c4ac635d17fe0ab9d331d7860726881f719ee560224b
+updated: 2017-08-22T19:05:22.898750196-07:00
 imports:
 - name: github.com/fission/fission
   version: 37aa266a4d4bd0484e66afbc5206b118638e77bf
   subpackages:
+  - controller/client
   - poolmgr/client
 - name: github.com/gogo/protobuf
   version: 100ba4e885062801d56799d78530b73b178a78f3
@@ -34,7 +35,7 @@ imports:
   - runtime/internal
   - utilities
 - name: github.com/nats-io/go-nats
-  version: 61923ed1eaf8398000991fbbee2ef11ab5a5be0d
+  version: 29f9728a183bf3fa7e809e14edac00b33be72088
 - name: github.com/nats-io/go-nats-streaming
   version: 6e620057a207bd61e992c1c5b6a2de7b6a4cb010
   subpackages:
@@ -51,7 +52,7 @@ imports:
 - name: github.com/sirupsen/logrus
   version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
 - name: github.com/urfave/cli
-  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: golang.org/x/net
   version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
   subpackages:
@@ -94,4 +95,8 @@ imports:
   - status
   - tap
   - transport
+- name: k8s.io/apimachinery
+  version: dc1f89aff9a7509782bde3b68824c8043a3e58cc
+  subpackages:
+  - pkg/labels
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,6 +25,7 @@ import:
   version: ^0.4.0
   subpackages:
   - gogoproto
+- package: github.com/golang/glog
 - package: k8s.io/apimachinery
   subpackages:
   - pkg/labels

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,3 +25,6 @@ import:
   version: ^0.4.0
   subpackages:
   - gogoproto
+- package: k8s.io/apimachinery
+  subpackages:
+  - pkg/labels

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -9,12 +9,17 @@ go_library(
         "//pkg/api/invocation:go_default_library",
         "//pkg/controller/query:go_default_library",
         "//pkg/projector/project:go_default_library",
+        "//pkg/projector/project/invocation:go_default_library",
         "//pkg/scheduler:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/types/events:go_default_library",
         "//pkg/types/typedvalues:go_default_library",
+        "//pkg/util/labels/kubelabels:go_default_library",
+        "//pkg/util/pubsub:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/selection:go_default_library",
     ],
 )
 

--- a/pkg/controller/query/BUILD.bazel
+++ b/pkg/controller/query/BUILD.bazel
@@ -7,6 +7,5 @@ go_library(
     deps = [
         "//pkg/types:go_default_library",
         "//pkg/types/typedvalues:go_default_library",
-        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/pkg/projector/BUILD.bazel
+++ b/pkg/projector/BUILD.bazel
@@ -7,5 +7,7 @@ go_library(
     deps = [
         "//pkg/eventstore:go_default_library",
         "//pkg/types:go_default_library",
+        "//pkg/types/events:go_default_library",
+        "//pkg/util/pubsub:go_default_library",
     ],
 )

--- a/pkg/projector/project/BUILD.bazel
+++ b/pkg/projector/project/BUILD.bazel
@@ -7,6 +7,6 @@ go_library(
     deps = [
         "//pkg/cache:go_default_library",
         "//pkg/types:go_default_library",
-        "//pkg/types/events:go_default_library",
+        "//pkg/util/pubsub:go_default_library",
     ],
 )

--- a/pkg/projector/project/invocation/BUILD.bazel
+++ b/pkg/projector/project/invocation/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
         "//pkg/projector/project:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/types/events:go_default_library",
+        "//pkg/util/labels/kubelabels:go_default_library",
+        "//pkg/util/pubsub:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/pkg/projector/project/types.go
+++ b/pkg/projector/project/types.go
@@ -1,16 +1,14 @@
 package project
 
 import (
-	"io"
-	"time"
-
 	"github.com/fission/fission-workflow/pkg/cache"
 	"github.com/fission/fission-workflow/pkg/types"
-	"github.com/fission/fission-workflow/pkg/types/events"
+	"github.com/fission/fission-workflow/pkg/util/pubsub"
 )
 
 type WorkflowProjector interface {
-	io.Closer
+	pubsub.Publisher
+
 	// Get projection from cache or attempt to replay it.
 	Get(subject string) (*types.Workflow, error)
 
@@ -25,7 +23,8 @@ type WorkflowProjector interface {
 }
 
 type InvocationProjector interface {
-	io.Closer
+	pubsub.Publisher
+
 	// Get projection from cache or attempt to replay it.
 	Get(subject string) (*types.WorkflowInvocation, error)
 
@@ -38,16 +37,4 @@ type InvocationProjector interface {
 
 	// Lists all subjects that fit the query
 	List(query string) ([]string, error)
-
-	// Suscribe to updates on subjects watched by this projector
-	Subscribe(updateCh chan *InvocationNotification) error
-}
-
-// TODO generify
-// In order to avoid leaking eventstore details
-type InvocationNotification struct {
-	Id   string
-	Data *types.WorkflowInvocation
-	Type events.Invocation
-	Time time.Time
 }

--- a/pkg/projector/project/workflow/BUILD.bazel
+++ b/pkg/projector/project/workflow/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/projector/project:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/types/events:go_default_library",
+        "//pkg/util/pubsub:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/pkg/projector/project/workflow/projector.go
+++ b/pkg/projector/project/workflow/projector.go
@@ -1,15 +1,18 @@
 package workflow
 
 import (
+	"strings"
+
 	"github.com/fission/fission-workflow/pkg/cache"
 	"github.com/fission/fission-workflow/pkg/eventstore"
 	"github.com/fission/fission-workflow/pkg/projector/project"
 	"github.com/fission/fission-workflow/pkg/types"
+	"github.com/fission/fission-workflow/pkg/util/pubsub"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 type workflowProjector struct {
+	pubsub.Publisher
 	esClient   eventstore.Client
 	cache      cache.Cache // TODO ensure concurrent
 	updateChan chan *eventstore.Event
@@ -17,6 +20,7 @@ type workflowProjector struct {
 
 func NewWorkflowProjector(esClient eventstore.Client, cache cache.Cache) project.WorkflowProjector {
 	p := &workflowProjector{
+		Publisher:  pubsub.NewPublisher(),
 		esClient:   esClient,
 		cache:      cache,
 		updateChan: make(chan *eventstore.Event),

--- a/pkg/projector/projection.go
+++ b/pkg/projector/projection.go
@@ -1,11 +1,8 @@
 package projector
 
 import (
-	"time"
-
 	"github.com/fission/fission-workflow/pkg/eventstore"
 	"github.com/fission/fission-workflow/pkg/types"
-	"github.com/fission/fission-workflow/pkg/types/events"
 	"github.com/fission/fission-workflow/pkg/util/pubsub"
 )
 
@@ -26,11 +23,3 @@ type Projector interface {
 	// Replays events, if it already exists, it is invalidated and replayed
 	Fetch(subject string) error
 }
-
-// In order to avoid leaking eventstore details
-//type InvocationNotification struct {
-//	Id   string
-//	Data *types.WorkflowInvocation
-//	Type events.Invocation
-//	Time *time.Time
-//}

--- a/pkg/projector/projection.go
+++ b/pkg/projector/projection.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fission/fission-workflow/pkg/eventstore"
 	"github.com/fission/fission-workflow/pkg/types"
 	"github.com/fission/fission-workflow/pkg/types/events"
+	"github.com/fission/fission-workflow/pkg/util/pubsub"
 )
 
 type Projection interface {
@@ -17,20 +18,19 @@ type Projection interface {
 
 // Per object type view only!!!
 type Projector interface {
+	pubsub.Publisher
+
 	// Get projection from cache or attempt to replay it.
 	Get(subject string) (*types.WorkflowInvocation, error)
 
 	// Replays events, if it already exists, it is invalidated and replayed
 	Fetch(subject string) error
-
-	// Suscribe to updates in this projector
-	Subscribe(chan *InvocationNotification) error
 }
 
 // In order to avoid leaking eventstore details
-type InvocationNotification struct {
-	Id   string
-	Data *types.WorkflowInvocation
-	Type events.Invocation
-	Time *time.Time
-}
+//type InvocationNotification struct {
+//	Id   string
+//	Data *types.WorkflowInvocation
+//	Type events.Invocation
+//	Time *time.Time
+//}

--- a/pkg/util/labels/BUILD.bazel
+++ b/pkg/util/labels/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["labels.go"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/labels/kubelabels/BUILD.bazel
+++ b/pkg/util/labels/kubelabels/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["kubelabels.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["kubelabels_test.go"],
+    library = ":go_default_library",
+    deps = ["//vendor/k8s.io/apimachinery/pkg/labels:go_default_library"],
+)

--- a/pkg/util/labels/kubelabels/kubelabels.go
+++ b/pkg/util/labels/kubelabels/kubelabels.go
@@ -1,8 +1,6 @@
 package kubelabels
 
 import (
-	"fmt"
-
 	"github.com/fission/fission-workflow/pkg/util/labels"
 	kubelabels "k8s.io/apimachinery/pkg/labels"
 )
@@ -10,21 +8,19 @@ import (
 type LabelSet kubelabels.Set
 
 type Labels struct {
-	labels kubelabels.Labels
+	kubelabels.Labels
 }
 
 func New(labelSet LabelSet) labels.Labels {
-	return &Labels{
-		labels: kubelabels.Set(labelSet),
-	}
-}
-
-func (kl *Labels) String() string {
-	return fmt.Sprintf("%v", kl.labels)
+	return &Labels{kubelabels.Set(labelSet)}
 }
 
 type Selector struct {
 	selector kubelabels.Selector
+}
+
+func NewSelector(selector kubelabels.Selector) *Selector {
+	return &Selector{selector}
 }
 
 func (kl *Selector) Matches(labels labels.Labels) bool {
@@ -36,5 +32,5 @@ func (kl *Selector) Matches(labels labels.Labels) bool {
 		return true
 	}
 
-	return kl.selector.Matches(klabel.labels)
+	return kl.selector.Matches(klabel)
 }

--- a/pkg/util/labels/kubelabels/kubelabels.go
+++ b/pkg/util/labels/kubelabels/kubelabels.go
@@ -1,0 +1,40 @@
+package kubelabels
+
+import (
+	"fmt"
+
+	"github.com/fission/fission-workflow/pkg/util/labels"
+	kubelabels "k8s.io/apimachinery/pkg/labels"
+)
+
+type LabelSet kubelabels.Set
+
+type Labels struct {
+	labels kubelabels.Labels
+}
+
+func New(labelSet LabelSet) labels.Labels {
+	return &Labels{
+		labels: kubelabels.Set(labelSet),
+	}
+}
+
+func (kl *Labels) String() string {
+	return fmt.Sprintf("%v", kl.labels)
+}
+
+type Selector struct {
+	selector kubelabels.Selector
+}
+
+func (kl *Selector) Matches(labels labels.Labels) bool {
+	klabel, ok := labels.(*Labels)
+	if !ok {
+		panic("Invalid label type")
+	}
+	if kl.selector.Empty() {
+		return true
+	}
+
+	return kl.selector.Matches(klabel.labels)
+}

--- a/pkg/util/labels/kubelabels/kubelabels_test.go
+++ b/pkg/util/labels/kubelabels/kubelabels_test.go
@@ -1,0 +1,35 @@
+package kubelabels
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestSelector(t *testing.T) {
+
+	lbls := New(map[string]string{
+		"foo": "bar",
+	})
+
+	selector := Selector{
+		selector: labels.Everything(),
+	}
+
+	if !selector.Matches(lbls) {
+		t.Error("Expected labels not matched")
+	}
+}
+
+func TestEmptyLabel(t *testing.T) {
+	lbls := New(nil)
+
+	selector := Selector{
+		selector: labels.Everything(),
+	}
+
+	if !selector.Matches(lbls) {
+		t.Error("Expected labels not matched")
+	}
+}
+

--- a/pkg/util/labels/kubelabels/kubelabels_test.go
+++ b/pkg/util/labels/kubelabels/kubelabels_test.go
@@ -32,4 +32,3 @@ func TestEmptyLabel(t *testing.T) {
 		t.Error("Expected labels not matched")
 	}
 }
-

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -1,0 +1,13 @@
+package labels
+
+import (
+	"fmt"
+)
+
+type Labels interface {
+	fmt.Stringer
+}
+
+type Selector interface {
+	Matches(labels Labels) bool
+}

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -1,11 +1,11 @@
 package labels
 
-import (
-	"fmt"
-)
-
 type Labels interface {
-	fmt.Stringer
+	// Has returns whether the provided label exists.
+	Has(label string) (exists bool)
+
+	// Get returns the value for the provided label.
+	Get(label string) (value string)
 }
 
 type Selector interface {

--- a/pkg/util/pubsub/BUILD.bazel
+++ b/pkg/util/pubsub/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pubsub.go"],
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util/labels:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["pubsub_test.go"],
+    library = ":go_default_library",
+    deps = ["//pkg/util/labels/kubelabels:go_default_library"],
+)

--- a/pkg/util/pubsub/pubsub.go
+++ b/pkg/util/pubsub/pubsub.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"sync"
 
+	"time"
+
 	"github.com/fission/fission-workflow/pkg/util/labels"
 )
 
@@ -12,6 +14,18 @@ const (
 	DEFAULT_SUB_CAP = 10
 )
 
+type Msg interface {
+	Labels() labels.Labels
+	CreatedAt() time.Time
+}
+
+type Publisher interface {
+	io.Closer
+	Subscribe(opts ...SubscriptionOptions) *Subscription
+	Unsubscribe(sub *Subscription) error
+	Publish(msg Msg) error
+}
+
 type SubscriptionOptions struct {
 	Buf           int
 	LabelSelector labels.Selector
@@ -19,19 +33,43 @@ type SubscriptionOptions struct {
 
 type Subscription struct {
 	SubscriptionOptions
-	Ch chan interface{}
+	Ch chan Msg
 }
 
-type Msg struct {
-	Labels  labels.Labels
-	Payload interface{}
+type EmptyMsg struct {
+	labels    labels.Labels
+	createdAt time.Time
 }
 
-type Publisher interface {
-	io.Closer
-	Subscribe(opts ...SubscriptionOptions) *Subscription
-	Unsubscribe(sub *Subscription) error
-	Publish(msg *Msg) error
+func (gm *EmptyMsg) Labels() labels.Labels {
+	return gm.labels
+}
+
+func (gm *EmptyMsg) CreatedAt() time.Time {
+	return gm.createdAt
+}
+
+type GenericMsg struct {
+	*EmptyMsg
+	payload interface{}
+}
+
+func NewEmptyMsg(lbls labels.Labels, createdAt time.Time) *EmptyMsg {
+	return &EmptyMsg{
+		labels:    lbls,
+		createdAt: createdAt,
+	}
+}
+
+func NewGenericMsg(lbls labels.Labels, createdAt time.Time, payload interface{}) *GenericMsg {
+	return &GenericMsg{
+		EmptyMsg: NewEmptyMsg(lbls, createdAt),
+		payload:  payload,
+	}
+}
+
+func (pm *GenericMsg) Payload() interface{} {
+	return pm.payload
 }
 
 func NewPublisher() Publisher {
@@ -71,7 +109,7 @@ func (pu *publisher) Subscribe(opts ...SubscriptionOptions) *Subscription {
 	}
 
 	sub := &Subscription{
-		Ch:                  make(chan interface{}, subOpts.Buf),
+		Ch:                  make(chan Msg, subOpts.Buf),
 		SubscriptionOptions: subOpts,
 	}
 
@@ -79,11 +117,11 @@ func (pu *publisher) Subscribe(opts ...SubscriptionOptions) *Subscription {
 	return sub
 }
 
-func (pu *publisher) Publish(msg *Msg) error {
+func (pu *publisher) Publish(msg Msg) error {
 	pu.lock.Lock()
 	defer pu.lock.Unlock()
 	for _, sub := range pu.subs {
-		if sub.LabelSelector != nil && !sub.LabelSelector.Matches(msg.Labels) {
+		if sub.LabelSelector != nil && !sub.LabelSelector.Matches(msg.Labels()) {
 			continue
 		}
 		select {

--- a/pkg/util/pubsub/pubsub.go
+++ b/pkg/util/pubsub/pubsub.go
@@ -11,7 +11,7 @@ import (
 
 // A simple PubSub implementation
 const (
-	DEFAULT_SUB_CAP = 10
+	DEFAULT_SUB_BUF = 10
 )
 
 type Msg interface {
@@ -105,7 +105,7 @@ func (pu *publisher) Subscribe(opts ...SubscriptionOptions) *Subscription {
 	}
 
 	if subOpts.Buf <= 0 {
-		subOpts.Buf = DEFAULT_SUB_CAP
+		subOpts.Buf = DEFAULT_SUB_BUF
 	}
 
 	sub := &Subscription{

--- a/pkg/util/pubsub/pubsub.go
+++ b/pkg/util/pubsub/pubsub.go
@@ -1,0 +1,106 @@
+package pubsub
+
+import (
+	"io"
+	"sync"
+
+	"github.com/fission/fission-workflow/pkg/util/labels"
+)
+
+// A simple PubSub implementation
+const (
+	DEFAULT_SUB_CAP = 10
+)
+
+type SubscriptionOptions struct {
+	Buf           int
+	LabelSelector labels.Selector
+}
+
+type Subscription struct {
+	SubscriptionOptions
+	Ch chan interface{}
+}
+
+type Msg struct {
+	Labels  labels.Labels
+	Payload interface{}
+}
+
+type Publisher interface {
+	io.Closer
+	Subscribe(opts ...SubscriptionOptions) *Subscription
+	Unsubscribe(sub *Subscription) error
+	Publish(msg *Msg) error
+}
+
+func NewPublisher() Publisher {
+	return &publisher{
+		subs: []*Subscription{},
+	}
+}
+
+type publisher struct {
+	subs []*Subscription
+	lock sync.Mutex
+}
+
+func (pu *publisher) Unsubscribe(sub *Subscription) error {
+	pu.lock.Lock()
+	defer pu.lock.Unlock()
+	close(sub.Ch)
+	updatedSubs := []*Subscription{}
+	for _, s := range pu.subs {
+		if sub != s {
+			updatedSubs = append(updatedSubs, s)
+		}
+	}
+	return nil
+}
+
+func (pu *publisher) Subscribe(opts ...SubscriptionOptions) *Subscription {
+	pu.lock.Lock()
+	defer pu.lock.Unlock()
+	var subOpts SubscriptionOptions
+	if len(opts) > 0 {
+		subOpts = opts[0]
+	}
+
+	if subOpts.Buf <= 0 {
+		subOpts.Buf = DEFAULT_SUB_CAP
+	}
+
+	sub := &Subscription{
+		Ch:                  make(chan interface{}, subOpts.Buf),
+		SubscriptionOptions: subOpts,
+	}
+
+	pu.subs = append(pu.subs, sub)
+	return sub
+}
+
+func (pu *publisher) Publish(msg *Msg) error {
+	pu.lock.Lock()
+	defer pu.lock.Unlock()
+	for _, sub := range pu.subs {
+		if sub.LabelSelector != nil && !sub.LabelSelector.Matches(msg.Labels) {
+			continue
+		}
+		select {
+		case sub.Ch <- msg:
+			// OK
+		default:
+			// Drop message if subscribers channel is full
+			// Future: allow subscribers to specify in options what should happen when their channel is full.
+		}
+	}
+	return nil
+}
+
+func (pu *publisher) Close() error {
+	var err error
+	for _, sub := range pu.subs {
+		err = pu.Unsubscribe(sub)
+	}
+	return err
+}

--- a/pkg/util/pubsub/pubsub_test.go
+++ b/pkg/util/pubsub/pubsub_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/fission/fission-workflow/pkg/util/labels/kubelabels"
+	"time"
 )
 
 func TestPublisherSubscribe(t *testing.T) {
@@ -25,7 +26,7 @@ func TestPublish(t *testing.T) {
 
 	msg := NewGenericMsg(kubelabels.New(map[string]string{
 		"foo": "bar",
-	}), "TestMsg")
+	}), time.Now(), "TestMsg")
 
 	err := pub.Publish(msg)
 	if err != nil {
@@ -52,11 +53,11 @@ func TestPublishBufferOverflow(t *testing.T) {
 
 	firstMsg := NewGenericMsg(kubelabels.New(map[string]string{
 		"foo": "bar",
-	}), "TestMsg1")
+	}), time.Now(), "TestMsg1")
 
 	secondMsg := NewGenericMsg(kubelabels.New(map[string]string{
 		"foo": "bar",
-	}), "TestMsg2")
+	}), time.Now(), "TestMsg2")
 
 	err := pub.Publish(firstMsg)
 	if err != nil {

--- a/pkg/util/pubsub/pubsub_test.go
+++ b/pkg/util/pubsub/pubsub_test.go
@@ -23,12 +23,9 @@ func TestPublish(t *testing.T) {
 		Buf: 1,
 	})
 
-	msg := &Msg{
-		Labels:  kubelabels.New(map[string]string{
-			"foo" : "bar",
-		}),
-		Payload: "TestMsg",
-	}
+	msg := NewGenericMsg(kubelabels.New(map[string]string{
+		"foo": "bar",
+	}), "TestMsg")
 
 	err := pub.Publish(msg)
 	if err != nil {
@@ -36,7 +33,7 @@ func TestPublish(t *testing.T) {
 	}
 	pub.Close()
 
-	err = expectMsgs(sub, []*Msg{
+	err = expectMsgs(sub, []Msg{
 		msg,
 	})
 	if err != nil {
@@ -53,18 +50,14 @@ func TestPublishBufferOverflow(t *testing.T) {
 		Buf: 10,
 	})
 
-	firstMsg := &Msg{
-		Labels:  kubelabels.New(map[string]string{
-			"foo" : "bar",
-		}),
-		Payload: "TestMsg1",
-	}
-	secondMsg := &Msg{
-		Labels:  kubelabels.New(map[string]string{
-			"foo" : "bar",
-		}),
-		Payload: "TestMsg2",
-	}
+	firstMsg := NewGenericMsg(kubelabels.New(map[string]string{
+		"foo": "bar",
+	}), "TestMsg1")
+
+	secondMsg := NewGenericMsg(kubelabels.New(map[string]string{
+		"foo": "bar",
+	}), "TestMsg2")
+
 	err := pub.Publish(firstMsg)
 	if err != nil {
 		t.Error(err)
@@ -75,14 +68,14 @@ func TestPublishBufferOverflow(t *testing.T) {
 	}
 	pub.Close()
 
-	err = expectMsgs(sub, []*Msg{
+	err = expectMsgs(sub, []Msg{
 		firstMsg,
 	})
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = expectMsgs(sub2, []*Msg{
+	err = expectMsgs(sub2, []Msg{
 		firstMsg,
 		secondMsg,
 	})
@@ -92,7 +85,7 @@ func TestPublishBufferOverflow(t *testing.T) {
 }
 
 // Note ensure that subscriptions are closed before this check
-func expectMsgs(sub *Subscription, expectedMsgs []*Msg) error {
+func expectMsgs(sub *Subscription, expectedMsgs []Msg) error {
 	i := 0
 	for msg := range sub.Ch {
 		if i > len(expectedMsgs) {

--- a/pkg/util/pubsub/pubsub_test.go
+++ b/pkg/util/pubsub/pubsub_test.go
@@ -1,0 +1,110 @@
+package pubsub
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fission/fission-workflow/pkg/util/labels/kubelabels"
+)
+
+func TestPublisherSubscribe(t *testing.T) {
+	pub := NewPublisher()
+	defer pub.Close()
+	sub := pub.Subscribe()
+
+	if sub == nil {
+		t.Error("Empty subscription provided")
+	}
+}
+
+func TestPublish(t *testing.T) {
+	pub := NewPublisher()
+	sub := pub.Subscribe(SubscriptionOptions{
+		Buf: 1,
+	})
+
+	msg := &Msg{
+		Labels:  kubelabels.New(map[string]string{
+			"foo" : "bar",
+		}),
+		Payload: "TestMsg",
+	}
+
+	err := pub.Publish(msg)
+	if err != nil {
+		t.Error(err)
+	}
+	pub.Close()
+
+	err = expectMsgs(sub, []*Msg{
+		msg,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPublishBufferOverflow(t *testing.T) {
+	pub := NewPublisher()
+	sub := pub.Subscribe(SubscriptionOptions{
+		Buf: 1,
+	})
+	sub2 := pub.Subscribe(SubscriptionOptions{
+		Buf: 10,
+	})
+
+	firstMsg := &Msg{
+		Labels:  kubelabels.New(map[string]string{
+			"foo" : "bar",
+		}),
+		Payload: "TestMsg1",
+	}
+	secondMsg := &Msg{
+		Labels:  kubelabels.New(map[string]string{
+			"foo" : "bar",
+		}),
+		Payload: "TestMsg2",
+	}
+	err := pub.Publish(firstMsg)
+	if err != nil {
+		t.Error(err)
+	}
+	err = pub.Publish(secondMsg)
+	if err != nil {
+		t.Error(err)
+	}
+	pub.Close()
+
+	err = expectMsgs(sub, []*Msg{
+		firstMsg,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = expectMsgs(sub2, []*Msg{
+		firstMsg,
+		secondMsg,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// Note ensure that subscriptions are closed before this check
+func expectMsgs(sub *Subscription, expectedMsgs []*Msg) error {
+	i := 0
+	for msg := range sub.Ch {
+		if i > len(expectedMsgs) {
+			return fmt.Errorf("Received unexpected msg '%v'", msg)
+		}
+		if msg != expectedMsgs[i] {
+			return fmt.Errorf("Received msg '%v' does not equal send msg '%v'", msg, expectedMsgs[i])
+		}
+		i = i + 1
+	}
+	if i != len(expectedMsgs) {
+		return fmt.Errorf("Did not receive expected msgs: %v", expectedMsgs[i+1:])
+	}
+	return nil
+}


### PR DESCRIPTION
This PR replaces the original simple gochannel-based notification functionality with a more generic PubSub-like solution. This label-based approach, allows subscribers to indicate in which events they are interested. This solves the issue that the controller received notifications for events it can't do anything about. 

In the future the NATS client can also be refactored to use this package instead.