### PR TITLE
Timeout + scope isolation in Otto interpreter

### DIFF
--- a/examples/simple/echowhale.wf.json
+++ b/examples/simple/echowhale.wf.json
@@ -4,7 +4,7 @@
   "tasks": {
     "whaleEcho": {
       "inputs" : {
-        "type" : "ref",
+        "type" : "expr",
         "value" : "$.invocation.inputs.default"
       },
       "name": "whalesay",

--- a/examples/simple/fortunewhale.wf.json
+++ b/examples/simple/fortunewhale.wf.json
@@ -8,7 +8,7 @@
     "generateFortune": {
       "name": "fortune",
       "inputs" : {
-        "type" : "ref",
+        "type" : "expr",
         "value" : "$.invocation.inputs.default"
       },
       "dependencies": {
@@ -19,7 +19,7 @@
       "name": "whalesay",
       "inputs" : {
         "default" : {
-          "type" : "ref",
+          "type" : "expr",
           "value" : "$.tasks.generateFortune.output"
         }
       },

--- a/pkg/controller/query/BUILD.bazel
+++ b/pkg/controller/query/BUILD.bazel
@@ -4,14 +4,13 @@ go_library(
     name = "go_default_library",
     srcs = [
         "expr.go",
-        "jsonpath.go",
-        "transformers.go",
+        "scope.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/types:go_default_library",
         "//pkg/types/typedvalues:go_default_library",
+        "//pkg/util:go_default_library",
         "//vendor/github.com/robertkrimen/otto:go_default_library",
-        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/pkg/controller/query/expr_test.go
+++ b/pkg/controller/query/expr_test.go
@@ -1,0 +1,104 @@
+package query
+
+import (
+	"testing"
+
+	"fmt"
+	"strings"
+
+	"github.com/fission/fission-workflow/pkg/types/typedvalues"
+)
+
+var pf = typedvalues.NewDefaultParserFormatter()
+
+var scope = map[string]interface{}{
+	"bit": "bat",
+}
+var rootscope = map[string]interface{}{
+	"foo":          "bar",
+	"currentScope": scope,
+}
+
+func TestResolveTestRootScopePath(t *testing.T) {
+
+	exprParser := NewJavascriptExpressionParser(pf)
+
+	resolved, err := exprParser.Resolve(rootscope, rootscope, typedvalues.Expr("$.currentScope.bit"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	resolvedString, err := pf.Format(resolved)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := scope["bit"]
+	if resolvedString != expected {
+		t.Errorf("Expected value '%v' does not match '%v'", expected, resolved)
+	}
+}
+
+func TestResolveTestScopePath(t *testing.T) {
+
+	exprParser := NewJavascriptExpressionParser(pf)
+
+	resolved, err := exprParser.Resolve(rootscope, scope, typedvalues.Expr("task.bit"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	resolvedString, err := pf.Format(resolved)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := scope["bit"]
+	if resolvedString != expected {
+		t.Errorf("Expected value '%v' does not match '%v'", expected, resolved)
+	}
+}
+
+func TestResolveLiteral(t *testing.T) {
+
+	exprParser := NewJavascriptExpressionParser(pf)
+
+	expected := "foobar"
+	resolved, _ := exprParser.Resolve(rootscope, scope, typedvalues.Expr(fmt.Sprintf("'%s'", expected)))
+
+	resolvedString, _ := pf.Format(resolved)
+	if resolvedString != expected {
+		t.Errorf("Expected value '%v' does not match '%v'", expected, resolved)
+	}
+}
+
+func TestResolveTransformation(t *testing.T) {
+
+	exprParser := NewJavascriptExpressionParser(pf)
+
+	src := "foobar"
+	resolved, _ := exprParser.Resolve(rootscope, scope, typedvalues.Expr(fmt.Sprintf("'%s'.toUpperCase()", src)))
+	expected := strings.ToUpper(src)
+
+	resolvedString, _ := pf.Format(resolved)
+	if resolvedString != expected {
+		t.Errorf("Expected value '%v' does not match '%v'", src, resolved)
+	}
+}
+
+func TestResolveInjectedFunction(t *testing.T) {
+
+	exprParser := NewJavascriptExpressionParser(pf)
+
+	resolved, err := exprParser.Resolve(rootscope, scope, typedvalues.Expr("uid()"))
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	resolvedString, _ := pf.Format(resolved)
+
+	if resolvedString == "" {
+		t.Error("Uid returned empty string")
+	}
+}


### PR DESCRIPTION
This PR adds some safety to the Otto JavaScript interpreter by placing a limit on the execution time (100ms) and ensure that there is not way that functions can share scope.

Flyby:
- updated examples