### PR TITLE
Add fission.FunctionRef parser/formatter

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a36a3a6e2b01f194bede83f16a2686262572e1916a0117f61fec92b372f4318e
-updated: 2017-09-08T18:26:10.105430717-07:00
+hash: 316f330dbf6768c9af0406741d5363ff650b76102299b4b7534b9cbb588cff12
+updated: 2017-09-12T15:19:09.437824118-07:00
 imports:
 - name: github.com/blang/semver
   version: 60ec3488bfea7cca02b021d106d9911120d25fe9
@@ -32,7 +32,7 @@ imports:
   - log
   - swagger
 - name: github.com/fission/fission
-  version: 1b9fa5bc3034c9816ceaf3a435c699faa5d8fe1c
+  version: dc50ebb8898d5474012ff20e88834a5966a8830e
   subpackages:
   - controller/client
   - poolmgr/client
@@ -77,7 +77,7 @@ imports:
 - name: github.com/gorilla/handlers
   version: a4043c62cc2329bacda331d33fc908ab11ef0ec3
 - name: github.com/gorilla/mux
-  version: bcd8bc72b08df0f70df986b97f95590779502d31
+  version: 24fca303ac6da784b9e8269f724ddeb0b2eea5e7
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: f2862b476edcef83412c7af8687c9cd8e4097c0f
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,7 +37,7 @@ import:
   version: v2.0.0
 - package: gopkg.in/yaml.v2
 - package: github.com/fission/fission
-  version: v0.2.0-20170901
+  version: v0.2.1
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/pkg/util/functionref/parserformatter.go
+++ b/pkg/util/functionref/parserformatter.go
@@ -1,0 +1,98 @@
+package functionref
+
+import (
+	"errors"
+
+	"github.com/fission/fission"
+)
+
+var (
+	ErrInvalidType  = errors.New("invalid type")
+	ErrParseFailed  = errors.New("failed to parse")
+	ErrFormatFailed = errors.New("failed to format")
+)
+
+type Parser interface {
+	Parse(ref interface{}) (fission.FunctionReference, error)
+}
+
+type Formatter interface {
+	Format(ref fission.FunctionReference) (string, error)
+}
+
+var DefaultParser Parser = &ComposedParser{[]Parser{
+	&SelfParser{},
+	&NameParserFormatter{},
+}}
+
+var DefaultFormatter Formatter = &ComposedFormatter{[]Formatter{
+	&NameParserFormatter{},
+}}
+
+func Format(ref fission.FunctionReference) (string, error) {
+	return DefaultFormatter.Format(ref)
+}
+
+func Parse(ref interface{}) (fission.FunctionReference, error) {
+	return DefaultParser.Parse(ref)
+}
+
+type ComposedParser struct {
+	Parsers []Parser
+}
+
+func (cp *ComposedParser) Parse(ref interface{}) (fission.FunctionReference, error) {
+	for _, parser := range cp.Parsers {
+		result, err := parser.Parse(ref)
+		if err == nil {
+			return result, nil
+		}
+	}
+	return fission.FunctionReference{}, ErrParseFailed
+}
+
+type ComposedFormatter struct {
+	Formatters []Formatter
+}
+
+func (cf *ComposedFormatter) Format(ref fission.FunctionReference) (string, error) {
+	for _, formatter := range cf.Formatters {
+		result, err := formatter.Format(ref)
+		if err == nil {
+			return result, nil
+		}
+	}
+	return "", ErrFormatFailed
+}
+
+type SelfParser struct{}
+
+func (sp *SelfParser) Parse(ref interface{}) (fission.FunctionReference, error) {
+	fnRef, ok := ref.(fission.FunctionReference)
+	if !ok {
+		return fission.FunctionReference{}, ErrInvalidType
+	}
+	return fnRef, nil
+}
+
+type NameParserFormatter struct{}
+
+func (np *NameParserFormatter) Format(ref fission.FunctionReference) (string, error) {
+	if ref.Type != fission.FunctionReferenceTypeFunctionName {
+		return "", ErrInvalidType
+	}
+
+	return ref.Name, nil
+}
+
+func (np *NameParserFormatter) Parse(ref interface{}) (fission.FunctionReference, error) {
+	refString, ok := ref.(string)
+	if !ok {
+		return fission.FunctionReference{}, ErrInvalidType
+	}
+
+	return fission.FunctionReference{
+		Type: fission.FunctionReferenceTypeFunctionName,
+		Name: refString,
+	}, nil
+}

--- a/pkg/util/functionref/parserformatter_test.go
+++ b/pkg/util/functionref/parserformatter_test.go
@@ -1,0 +1,68 @@
+package functionref
+
+import (
+	"testing"
+
+	"github.com/fission/fission"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelfParser_Parse(t *testing.T) {
+	subject := fission.FunctionReference{
+		Type: "foo",
+		Name: "bar",
+	}
+	parser := &SelfParser{}
+	ref, err := parser.Parse(subject)
+	assert.NoError(t, err)
+	assert.Equal(t, subject, ref)
+}
+
+func TestSelfParser_Parse_Failed(t *testing.T) {
+	subject := "foo"
+	parser := &SelfParser{}
+	_, err := parser.Parse(subject)
+	assert.Error(t, err)
+}
+
+func TestNameParserFormatter_Parse(t *testing.T) {
+	subject := "foo"
+	parser := &NameParserFormatter{}
+	ref, err := parser.Parse(subject)
+	assert.NoError(t, err)
+	assert.Equal(t, fission.FunctionReference{
+		Type: fission.FunctionReferenceTypeFunctionName,
+		Name: subject,
+	}, ref)
+}
+
+func TestNameParserFormatter_Parse_Failed(t *testing.T) {
+	subject := fission.FunctionReference{
+		Type: "foo",
+		Name: "bar",
+	}
+	parser := &NameParserFormatter{}
+	_, err := parser.Parse(subject)
+	assert.Error(t, err)
+}
+
+func TestNameParserFormatter_Format(t *testing.T) {
+	subject := fission.FunctionReference{
+		Type: fission.FunctionReferenceTypeFunctionName,
+		Name: "bar",
+	}
+	parser := &NameParserFormatter{}
+	formatted, err := parser.Format(subject)
+	assert.NoError(t, err)
+	assert.Equal(t, subject.Name, formatted)
+}
+
+func TestNameParserFormatter_Format_Failed(t *testing.T) {
+	subject := fission.FunctionReference{
+		Type: "someOtherType",
+		Name: "bar",
+	}
+	parser := &NameParserFormatter{}
+	_, err := parser.Format(subject)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This utility is needed to be able to resolve a task FunctionRef to the corresponding fission.FunctionRef.